### PR TITLE
Remove unused code `gen_code/gen_julia_code.jl`

### DIFF
--- a/src/code_gen/gen_code_mem.jl
+++ b/src/code_gen/gen_code_mem.jl
@@ -39,10 +39,6 @@ function get_slot_name(mem::CodeMem, node::Symbol)
     end
 end
 
-function is_allocated(mem::CodeMem, node::Symbol)
-    return node in mem.slots
-end
-
 # Returns a reference to a memory slot
 # which is either a new slot or
 # one of the elements in the Vector allow_inplace

--- a/src/code_gen/gen_code_snippets.jl
+++ b/src/code_gen/gen_code_snippets.jl
@@ -12,11 +12,6 @@ function push_code!(code, str; ind_lvl = 1, ind_str = "    ")
     indented_string = isempty(str) ? "" : indentation * str
     return push!(code.code_lines, indented_string)
 end
-function push_code_verbatim_string!(code, str)
-    for line in split(str, "\n")
-        push!(code.code_lines, line)
-    end
-end
 function push_comment!(code, str; ind_lvl = 1, ind_str = "    ")
     # Convert empty comments to empty lines.
     return push_code!(

--- a/src/code_gen/gen_julia_code.jl
+++ b/src/code_gen/gen_julia_code.jl
@@ -272,19 +272,7 @@ function execute_operation!(
 
         # Adjust the result with inplace additions of identity
         for c in id_coeffs
-            if VERSION > v"1.7.0-DEV.1240"
-                push_code!(code, "mul!($nodemem,true,I*$c,true,true)")
-            else
-                push_comment!(
-                    code,
-                    "This julia version does not support inplace identity add.",
-                )
-                push_comment!(
-                    code,
-                    "Update to Julia 1.7.0 or newer for better performance.",
-                )
-                push_code!(code, "$nodemem+=I*$c")
-            end
+            push_code!(code, "mul!($nodemem, true, I*$c, true, true)")
         end
 
         if !(isnothing(recycle_parent))

--- a/test/code_gen_test.jl
+++ b/test/code_gen_test.jl
@@ -24,9 +24,7 @@ using LinearAlgebra, StaticArrays
                 TT = eltype(a);
                 A = convert.(TT,[3 4.0; 5.5 0.1]);
                 ti = time_ns()
-                lang = LangJulia(t1,t2,
-                                 value_one_name="ValueOne_"*string(ti),
-                                 axpby_name="matfun_axpby_"*string(ti)*"!")
+                lang = LangJulia(t1, t2)
                 fname = tempname() * ".jl"
                 begin # To avoid generated codes interfere
                     gen_code(fname, graph, lang = lang, funname = "dummy_$(ti)")
@@ -44,9 +42,7 @@ using LinearAlgebra, StaticArrays
     # Test Statically sized matrix
     (graph, crefs) = graph_ps_degopt([3 4 2 1 0.1 1.0])
     fname = tempname() * ".jl"
-    lang = LangJulia(true,true,
-                     value_one_name="ValueOne_"*string(time_ns()),
-                     axpby_name="matfun_axpby_"*string(time_ns())*"!")
+    lang = LangJulia(true, true)
     begin
         gen_code(fname, graph, funname = "thisfunction",lang=lang)
         # and execution
@@ -60,9 +56,7 @@ using LinearAlgebra, StaticArrays
 
     # Test precomputed nodes
     fname = tempname() * ".jl"
-    lang = LangJulia(true,true,
-                     value_one_name="ValueOne_"*string(time_ns()),
-                     axpby_name="matfun_axpby_"*string(time_ns())*"!")
+    lang = LangJulia(true, true)
     begin
         gen_code(fname, graph, funname = "thisfunction2",precomputed_nodes=[:A,:A2])
         # and execution

--- a/test/code_gen_test.jl
+++ b/test/code_gen_test.jl
@@ -42,7 +42,7 @@ using LinearAlgebra, StaticArrays
     # Test Statically sized matrix
     (graph, crefs) = graph_ps_degopt([3 4 2 1 0.1 1.0])
     fname = tempname() * ".jl"
-    lang = LangJulia(true, true)
+    lang = LangJulia(true)
     begin
         gen_code(fname, graph, funname = "thisfunction",lang=lang)
         # and execution
@@ -56,7 +56,7 @@ using LinearAlgebra, StaticArrays
 
     # Test precomputed nodes
     fname = tempname() * ".jl"
-    lang = LangJulia(true, true)
+    lang = LangJulia(true)
     begin
         gen_code(fname, graph, funname = "thisfunction2",precomputed_nodes=[:A,:A2])
         # and execution


### PR DESCRIPTION
After the `lincomb` update, there is a lot of unused code in this file. This PR is to clean things up a bit. I've only removed the obvious things for now, but it seems to me that everything having to do with the `axpby_header` can go, as this was only used in code that I've removed.