### PR TITLE
refactor linlsqr to allowed user defined linlsqr

### DIFF
--- a/src/optimization/gauss_newton.jl
+++ b/src/optimization/gauss_newton.jl
@@ -70,7 +70,12 @@ function opt_gauss_newton!(
             break
         end
 
-        d = solve_linlsqr!(Jac, res, linlsqr, droptol)
+        if (linlsqr isa LinLsqrSolve) # Refactored behaviour
+            d = solve_linlsqr!(Jac, res, linlsqr)
+        else # Old behavior
+            d = solve_linlsqr!(Jac, res, linlsqr, droptol)
+        end
+
         x = get_coeffs(graph, cref)
         x -= γ0 * d
         set_coeffs!(graph, x, cref)


### PR DESCRIPTION
This allows for advanced user defined linear least squares in gauss newton.

I needed a SVD-solver that accepts a fixed number of svd-vals, instead of tolerance based. 

Trying to maintain legacy kwargs. 

W.I.P

 